### PR TITLE
Use `merge-stream-in-chunks` module when merging output of a shell command for different repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "colors": "1.1.2",
     "commander": "2.9.0",
     "immutable": "3.7.6",
-    "prepend-transform": "0.0.1019",
+    "merge-stream-in-chunks": "^0.1.2",
     "simple-git": "1.25.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This has two benefits:
* Makes overall output look nicer while still having output for different repositories clearly distinguishable.
For example when running `git bulk exec -c 'git status'`:
![image](https://user-images.githubusercontent.com/2260810/85478158-6622de00-b5c4-11ea-8d89-8fa3f79ab78d.png)
* Replaces `prepend-transform` dependency with a dependency on a module that I myself created and will maintain

### Depends on
https://github.com/andreiled/merge-stream-in-chunks/pull/1